### PR TITLE
LEXIO-37887 Add more operator support to binary and unary expressions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pysaql"
-version = "0.6.0"
+version = "0.7.0"
 description = "Python SAQL query builder"
 authors = ["Jonathan Drake <jon.drake@salesforce.com>"]
 license = "BSD-3-Clause"

--- a/pysaql/__init__.py
+++ b/pysaql/__init__.py
@@ -1,3 +1,3 @@
 """Python SAQL query builder"""
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -84,7 +84,7 @@ def test_complex():
         """q1 = load "opportunities";""",
         """q1 = foreach q1 generate 'name', coalesce('number', 'other number', 0);""",
         """q1 = fill q1 by (dateCols=('Year', 'Month', "Y-M"), partition='Type');""",
-        """q1 = filter q1 by 'name' == "abc" && ! 'flag' && ('number' > 0 || 'number' < 0) && 'empty' is null && 'list' in ["ny", "ma"] && 'closed_date' in [date(2022, 1).."2 months ago"];""",
+        """q1 = filter q1 by ((((('name' == "abc") && ! 'flag') && (('number' > 0) || ('number' < 0))) && ('empty' is null)) && ('list' in ["ny", "ma"])) && ('closed_date' in [date(2022, 1).."2 months ago"]);""",
         """q1 = foreach q1 generate sum('amount') over ([..2] partition by ('region', 'state') order by sum('amount') desc) as 'total amount', dense_rank() over ([..] partition by 'county' order by 'region' asc) as 'total amount';""",
         """q2 = cogroup q0 by 'Day in Week' full, q1 by 'Day in Week';""",
     ]

--- a/tests/unit/test_scalar.py
+++ b/tests/unit/test_scalar.py
@@ -1,7 +1,7 @@
 """Contains unit tests for the scalar module"""
 
 
-from pysaql.scalar import field
+from pysaql.scalar import field, literal
 
 
 def test_alias():
@@ -59,6 +59,16 @@ def test_truediv():
     assert str(field("foo") / 10) == """'foo' / 10"""
 
 
+def test_truediv__literal_right():
+    """Should allow a literal value as the right operand when the left operand is a binary operation"""
+    assert str((field("foo") / 10) * 100) == """('foo' / 10) * 100"""
+
+
+def test_truediv__literal_left():
+    """Should require a literal value as the left operand when the right operand is a binary operation"""
+    assert str(literal(100) * (field("foo") / 10)) == """100 * ('foo' / 10)"""
+
+
 def test_neg():
     """Should return string for neg operation"""
     assert str(-field("foo")) == """- 'foo'"""
@@ -72,14 +82,16 @@ def test_in():
 def test_and():
     """Should return string for and operation"""
     assert (
-        str((field("foo") > 0) & (field("foo") < 10)) == """'foo' > 0 && 'foo' < 10"""
+        str((field("foo") > 0) & (field("foo") < 10))
+        == """('foo' > 0) && ('foo' < 10)"""
     )
 
 
 def test_or():
     """Should return string for or operation"""
     assert (
-        str((field("foo") > 0) | (field("foo") < 10)) == """('foo' > 0 || 'foo' < 10)"""
+        str((field("foo") > 0) | (field("foo") < 10))
+        == """('foo' > 0) || ('foo' < 10)"""
     )
 
 

--- a/tests/unit/test_stream.py
+++ b/tests/unit/test_stream.py
@@ -92,7 +92,7 @@ def test_filter__multiple():
     """Should filter by a multiple conditions"""
     stream = Stream()
     stream.filter(field("name") == "foo", field("bar") == "baz")
-    assert str(stream) == """q0 = filter q0 by 'name' == "foo" && 'bar' == "baz";"""
+    assert str(stream) == """q0 = filter q0 by ('name' == "foo") && ('bar' == "baz");"""
 
 
 def test_limit__invalid():


### PR DESCRIPTION
# Overview of changes
- Add more operator support to binary and unary expressions. This means that we can change binary operations with operators e.g. `(a / b) * 100`. The only thing that needed to change was having Binary and Unary extend Scalar. The diff is just moving things around in the module.
- Adds explicit parentheses to nested binary operations to preserve order of operations. This is necessary in some circumstances so we might as well be safe. 
- Adds a literal expression that is needed if a literal value is used first in a binary expression. For example, `a * 100` worked already, but `100 * a` would throw an exception. Wrapping the literal in an expression makes it work. This is pretty similar to SQLAlchemy.

## For software test
PR tests pass. Nested binary expressions work.