### PR TITLE
LEXIO-38100 Refactor ID setting algorithm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pysaql"
-version = "0.10.0"
+version = "0.11.0"
 description = "Python SAQL query builder"
 authors = ["Jonathan Drake <jon.drake@salesforce.com>"]
 license = "BSD-3-Clause"

--- a/pysaql/__init__.py
+++ b/pysaql/__init__.py
@@ -1,3 +1,3 @@
 """Python SAQL query builder"""
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"

--- a/pysaql/util.py
+++ b/pysaql/util.py
@@ -65,3 +65,20 @@ def stringify_list(seq: Sequence) -> str:
     """
     seq = [seq] if not isinstance(seq, (list, tuple, set)) else seq
     return f"({', '.join(str(s) for s in seq)})" if len(seq) > 1 else str(seq[0])
+
+
+def flatten(seq: list) -> list:
+    """Recursively flatten a list
+
+    Args:
+        seq: Sequence of items
+
+    Returns:
+        flatten list of items
+
+    """
+    if not seq:
+        return seq
+    if isinstance(seq[0], list):
+        return flatten(seq[0]) + flatten(seq[1:])
+    return seq[:1] + flatten(seq[1:])

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -54,3 +54,13 @@ def test_stringify_list__one():
 def test_stringify_list__multiple():
     """Should stringify a list with one item"""
     assert mod_ut.stringify_list(["foo", "bar"]) == "(foo, bar)"
+
+
+def test_flatten__empty():
+    """Should return empty list"""
+    assert mod_ut.flatten([]) == []
+
+
+def test_flatten__nested():
+    """Should flatten nested list"""
+    assert mod_ut.flatten([1, [2, [3, [4, 5]], 6], 7]) == [1, 2, 3, 4, 5, 6, 7]


### PR DESCRIPTION
# Overview of changes
I noticed that the drivers of change expression wasn't probably generating stream IDs (`q0 = ...`) properly. This PR refactors the algorithm used to set the IDs. It builds up a big list of streams and then simply names the streams using an incrementing counter. 

## For software test
PR tests pass