### PR TITLE
LEXIO-38100 Don't deepcopy expression in alias method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pysaql"
-version = "0.11.0"
+version = "0.12.0"
 description = "Python SAQL query builder"
 authors = ["Jonathan Drake <jon.drake@salesforce.com>"]
 license = "BSD-3-Clause"

--- a/pysaql/__init__.py
+++ b/pysaql/__init__.py
@@ -1,3 +1,3 @@
 """Python SAQL query builder"""
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"

--- a/pysaql/expression.py
+++ b/pysaql/expression.py
@@ -2,7 +2,6 @@
 
 
 from abc import ABC, abstractmethod
-from copy import deepcopy
 from typing import Optional
 
 from .util import escape_identifier
@@ -20,9 +19,6 @@ class Expression(ABC):
     def alias(self, name: str) -> "Expression":
         """Set the alias name
 
-        This creates and returns a new expression object so a single field can be
-        aliased multiple times.
-
         Args:
             name: Alias name
 
@@ -30,9 +26,8 @@ class Expression(ABC):
             new expression object with alias
 
         """
-        new_expr = deepcopy(self)
-        new_expr._alias = name
-        return new_expr
+        self._alias = name
+        return self
 
     @abstractmethod
     def to_string(self) -> str:


### PR DESCRIPTION
# Overview of changes
Don't deepcopy expression in alias method because this messes with streams that use scoped fields (`stream.field("foo")`). 

By using `deepcopy`, we were inadvertantly copying the field's stream object and breaking the link that was needing for stream ID management.

## For software test
PR tests pass